### PR TITLE
Fix for issue #29.  Broken path when creating USB stick

### DIFF
--- a/CreateUsbStick.ps1
+++ b/CreateUsbStick.ps1
@@ -73,7 +73,7 @@ $ElapsedTime = Measure-Command {
         } else {
             # Copy files
             Write-Host "Copying file: $RelativePath" -ForegroundColor Green
-            New-Item -ItemType Directory -Path (Split-Path $DestinationFile) -Force | Out-Null
+            #New-Item -ItemType Directory -Path (Split-Path $DestinationFile) -Force | Out-Null
             Copy-Item -Path $_.FullName -Destination $DestinationFile -Force
         }
     }


### PR DESCRIPTION
I just commented the offending line.  Not sure what that line is trying to do, but it's broken.